### PR TITLE
Creates validation helper and clean up

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -30,7 +30,37 @@ class Board
     @cells[coordinate] != nil
   end
 
-  def check_consecutive(ship, coordinates_to_check) #coordinate_type is either rows or cols
+  def valid_placement?(ship, coordinates)
+    # put in an if
+    # ship.length == coordinates.count #ship @length should be same as count of coordinates
+
+    # This section parses the input coordinates and creates
+    # two separate arrays of rows and columns.
+    # NOTE: could be refactored into separate helper method later
+    rows = []
+    columns = []
+    coordinates.each do |coordinate|
+      rows << coordinate[0]
+      columns << coordinate[1]
+    end
+
+    # Conditional flow control begins here:
+    # Logic is either rows or columns must be consecutive
+    # and the other must have static values. For example:
+    # In the coordinates [A1, A2, A3], row (A) stays static and column (1, 2, 3) increments
+    # Note: Coordinates will be entered L->R or T->B order
+    if check_consecutive(ship, rows) && check_static(columns)
+      true
+    elsif check_consecutive(ship, columns) && check_static(rows)
+      true
+    else
+      false
+    end
+
+  end
+
+  # Helper method is flexible enough to test rows or columns are consecutive
+  def check_consecutive(ship, parsed_coordinates)
     #generate array of arrays of valid rows/cols
     consecutive_coordinates = []
 
@@ -42,37 +72,14 @@ class Board
       consecutive_coordinates << column
     end
 
-    consecutive_coordinates.include?(coordinates_to_check)
+    consecutive_coordinates.include?(parsed_coordinates)
     #expect to return a boolean true or false
   end
 
-  def valid_placement?(ship, coordinates)
-    # put in an if
-    # ship.length == coordinates.count #ship @length should be same as count of coordinates
-
-    # either rows or columns needs to increment by 1
-    # coordinates will be entered L->R or T->B order
-    # row_start = coordinates[0][0] #Letter
-    # col_start = coordinates[0][1] #Number
-
-    rows = []
-    cols = []
-    coordinates.each do |coordinate|
-      rows << coordinate[0]
-      cols << coordinate[1]
-    end
-
-    # require 'pry'; binding.pry
-
-    if check_consecutive(ship, rows)
-        # check that columns are the same
-        puts "check that the cols are the same!"
-    elsif check_consecutive(ship, cols)
-        #check that rows are the same
-        puts "check that the rows are the same!"
-    else
-      return false
-    end
-
+  # This method uses the #all? enumerable to check to see
+  # if all parsed coordinates are equal to each other
+  def check_static(parsed_coordinates)
+    parsed_coordinates.all? { |coordinate| coordinate == parsed_coordinates[0]}
   end
+
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -31,7 +31,7 @@ class Board
   end
 
   def valid_placement?(ship, coordinates)
-    # put in an if
+    # put in an if statement here to encapsulate whole method block
     # ship.length == coordinates.count #ship @length should be same as count of coordinates
 
     # This section parses the input coordinates and creates
@@ -68,10 +68,12 @@ class Board
       consecutive_coordinates << row
     end
 
+    # BUG HERE: columns are being generated as ints
+    # but are compared against strings when given full coordinates
     @columns.to_a.each_cons(ship.length) do |column|
       consecutive_coordinates << column
     end
-
+    # require 'pry'; binding.pry
     consecutive_coordinates.include?(parsed_coordinates)
     #expect to return a boolean true or false
   end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Board do
       expect(board.valid_placement?(cruiser, ["A3"])).to eq(false)
     end
 
-    xit 'validates that coordinates are consecutive either in rows or cols' do
+    it 'validates that coordinates are consecutive either in rows or cols' do
       expect(board.valid_placement?(cruiser, ["A1", "A2", "A3"])).to eq(true)
     end
   end
@@ -58,6 +58,20 @@ RSpec.describe Board do
 
     it 'returns true for consecutive letters on board' do
       expect(board.check_consecutive(cruiser, [1, 2, 3])).to eq(true)
+    end
+  end
+
+  describe "#check_static" do
+    board = Board.new
+    cruiser = Ship.new("Cruiser", 3)
+    submarine = Ship.new("Submarine", 2)
+
+    it 'returns true if columns do not change' do
+      expect(board.check_static([2, 2, 2])).to eq(true)
+    end
+
+    it 'returns false if rows change' do
+      expect(board.check_static(["A", "B", "C"])).to eq(false)
     end
   end
 


### PR DESCRIPTION
This PR creates a helper method for `valid_placement` and cleans up the `valid_placement` method as well. Note that the bug causing failing tests was identified in the `check_consecutive` method on line 73. See full commit message for more detail re: bug behavior: 01488d86eb81096c4a00d3169db1737e4636822e