### PR TITLE
Refine random_generator and adds helper method

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -79,7 +79,26 @@ class Game
     # 5b. If not valid, re-do loop from #2 onwards
   end
 
-  def generate_ship_possibilities(board, ship)
+  # Seed is passed as a range between num of columns of board
+  def generate_random_coordinates(board, coord_array, seed)
+    coord_pairs = []
+    coord_array.each do |array|
+      if array[0].is_a? Integer
+         coord_pairs << array.map do |coordinate|
+          board.rows.to_a[seed] + coordinate.to_s
+        end
+      elsif array[0].is_a? String
+        coord_pairs << array.map do |coordinate|
+          coordinate + board.columns.to_a[seed].to_s
+        end
+      end
+    end
+    coord_pairs.sample
+    #require 'pry';binding.pry
+  end
+
+  # Helper method to be used with #generate_random_coordinates
+  def create_coordinate_array(board, ship)
     #generate array of arrays of valid rows/cols
     consecutive_coordinates = []
 
@@ -89,22 +108,7 @@ class Game
     board.columns.to_a.each_cons(ship.length) do |column|
       consecutive_coordinates << column
     end
-
-    coord_pairs = []
-    consecutive_coordinates.each do |array|
-      #seed = consecutive_coordinates.sample
-      if array[0].is_a? Integer
-         coord_pairs << array.map do |coordinate|
-          board.rows.to_a.sample + coordinate.to_s
-        end
-      elsif array[0].is_a? String
-        coord_pairs << array.map do |coordinate|
-          coordinate + board.columns.to_a.sample.to_s
-        end
-      end
-    end
-    coord_pairs
-    #require 'pry';binding.pry
+    consecutive_coordinates
   end
 
 

--- a/spec/game-spec.rb
+++ b/spec/game-spec.rb
@@ -26,13 +26,14 @@ describe Game do
     end
   end
 
-  describe "#generate_ship_possibilities" do
+  describe "#generate_random_coordinates" do
     game = Game.new
     cpu_board = Board.new
     ship = Ship.new("cruiser", 3)
+    starting_array = game.create_coordinate_array(cpu_board, ship)
 
-    it 'returns array of arrays' do
-      expect(game.generate_ship_possibilities(cpu_board, ship)[0]).to be_instance_of(Array)
+    it 'returns array' do
+      expect(game.generate_random_coordinates(cpu_board, starting_array, 1)).to be_instance_of(Array)
     end
   end
 end


### PR DESCRIPTION
This PR refines `generate_random_coordinates` to return only one set of coordinates when passed a certain seed value. This allows it be implemented with the AM random generator algorithm during cpu setup.